### PR TITLE
Don't send empty suggestions

### DIFF
--- a/background.js
+++ b/background.js
@@ -39,7 +39,7 @@ const passOnTypeaheadResultToOmnibox = ({ suggest, typeaheadResult }) => {
   const suggestions = typeaheadResult.data.map((task) => ({
     content: task.gid,
     description: task.name,
-  }));
+  })).filter((suggestion) => suggestion.description.length > 0);
   console.log('suggestions:', suggestions);
   suggest(suggestions);
 };


### PR DESCRIPTION
Avoid this error:

TypeError: Error in invocation of omnibox.sendSuggestions(integer requestId, array suggestResults): Error at parameter 'suggestResults': Error at index 1: Error at property 'description': String must have at least 1 characters; found 0.