### PR TITLE
Add name to package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "upvoter_for_asana",
       "version": "0.1.0",
       "license": "MIT license",
       "dependencies": {


### PR DESCRIPTION
Seems to be added by npm install in some circumstances but not others?

https://app.circleci.com/pipelines/github/apiology/upvoter_for_asana/143/workflows/ab1d6576-7eb7-404a-95d9-c6372dfbdb66/jobs/180